### PR TITLE
fix(django): set environment variable at the beginning of migrate

### DIFF
--- a/decide/manage.py
+++ b/decide/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    #os.environ.setdefault("DJANGO_SETTINGS_MODULE", "decide.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "decide.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Fixes #1